### PR TITLE
fix(parser): ignore undefined recipes

### DIFF
--- a/src/metricGroups/resources.ts
+++ b/src/metricGroups/resources.ts
@@ -39,6 +39,10 @@ export const parser = (object: SaveComponent | SaveEntity, lookups: Lookups): vo
 
     const recipe = pathToRecipe(object.properties.mCurrentRecipe.value.pathName)
 
+    if (recipe === undefined) {
+      return
+    }
+
     for (const ingredient of recipe.ingredients) {
       const item = staticData.items[ingredient.item]
       metrics.getGauge('consumption_per_second').inc({ item: item.name }, (ingredient.amount / recipe.time) * clockSpeed)


### PR DESCRIPTION
Instead of the exporter crashing, undefined recipes will be skipped.