### PR TITLE
fix: Update to satisfactory-file-parser v3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
-        "@etothepii/satisfactory-file-parser": "^1.1.1",
+        "@etothepii/satisfactory-file-parser": "^3.3.0",
         "express": "^4.21.1",
         "prom-client": "^15.1.3"
       },
@@ -495,9 +495,10 @@
       }
     },
     "node_modules/@etothepii/satisfactory-file-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@etothepii/satisfactory-file-parser/-/satisfactory-file-parser-1.1.1.tgz",
-      "integrity": "sha512-CeOfzbek1X+XUfb5FQWhenza4dZapFejD/fbAjIMoln+SBKXM1rnzbhCMWuMAD72E3niAASGkIc1D3WnazLztQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@etothepii/satisfactory-file-parser/-/satisfactory-file-parser-3.3.0.tgz",
+      "integrity": "sha512-U3e2SXy0MOCp2BNuDZ8iOLX5n5NAk1/ndQqHaRDLU7g9Fh1ZgI9nz1r9nsdzt2e4TAvohe/ccfTDb4dOcBqV1w==",
+      "license": "MIT",
       "dependencies": {
         "pako": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
-    "@etothepii/satisfactory-file-parser": "^1.1.1",
+    "@etothepii/satisfactory-file-parser": "^3.3.0",
     "express": "^4.21.1",
     "prom-client": "^15.1.3"
   }

--- a/src/extractMetrics.ts
+++ b/src/extractMetrics.ts
@@ -24,7 +24,7 @@ export const extractMetrics = async (arrayBuffer: ArrayBuffer): Promise<Registry
   ])
 
   register.resetMetrics()
-  const save = Parser.ParseSave('MySave', new Uint8Array(arrayBuffer))
+  const save = Parser.ParseSave('MySave', arrayBuffer)
   register.setDefaultLabels({ sessionName: save.header.sessionName })
 
   const lookups = {
@@ -33,14 +33,14 @@ export const extractMetrics = async (arrayBuffer: ArrayBuffer): Promise<Registry
   } as const
 
   // Build lookup maps in an initial pass
-  for (const level of save.levels) {
+  for (const level of Object.values(save.levels)) {
     for (const object of level.objects) {
       lookups.byType.set(object.typePath, object)
       lookups.byInstance.set(object.instanceName, object)
     }
   }
 
-  for (const level of save.levels) {
+  for (const level of Object.values(save.levels)) {
     for (const object of level.objects) {
       awesomeParser(object, lookups)
       buildingsParser(object, lookups)

--- a/src/metricGroups/awesome.ts
+++ b/src/metricGroups/awesome.ts
@@ -1,8 +1,8 @@
 import { MetricGroup } from './_MetricGroup'
 import { type Lookups } from '../types/lookups.type'
 import {
-  type ArrayProperty,
   type Int32Property,
+  type Int64ArrayProperty,
   type SaveComponent,
   type SaveEntity,
 } from '@etothepii/satisfactory-file-parser'
@@ -16,12 +16,11 @@ const metrics = new MetricGroup('satisfactory_savegame_awesome')
     'printable',
     'AWESOME coupons that are currently printable',
   )
-
 /* eslint-disable no-useless-return */
 export const parser = (object: SaveComponent | SaveEntity, lookups: Lookups): void => {
   if (object.typePath === '/Script/FactoryGame.FGResourceSinkSubsystem') {
     // Total all-time, split by Standard and DNA
-    const mTotalPoints = (object?.properties?.mTotalPoints as ArrayProperty<string>)?.values?.map(s => parseInt(s, 10))
+    const mTotalPoints = (object?.properties?.mTotalPoints as Int64ArrayProperty)?.values?.map((s) => parseInt(s, 10))
     if (mTotalPoints) {
       metrics.getGauge('points').set(mTotalPoints.reduce((acc, value) => acc + value, 0))
     }

--- a/src/metricGroups/buildings.ts
+++ b/src/metricGroups/buildings.ts
@@ -29,9 +29,13 @@ export const parser = (object: SaveComponent | SaveEntity, lookups: Lookups): vo
   if (object.typePath === '/Script/FactoryGame.FGLightweightBuildableSubsystem') {
     if (isBuildableSubsystemSpecialProperties(object.specialProperties)) {
       for (const buildable of object.specialProperties.buildables) {
+        // Skip buildables without a valid typeReference path
+        const typePath = buildable.typeReference?.pathName
+        if (!typePath) continue
+
         // Because there are so many variations of walls and foundations, we group them.
         // E.g. '/Game/FactoryGame/Buildable/Building/Wall/FicsitWallSet/Build_Wall_Orange_8x1.Build_Wall_Orange_8x1_C'
-        const category = buildable.typePath.split('/')[5]
+        const category = typePath.split('/')[5] ?? 'Unknown'
         metrics.getGauge('lightweight_total').inc({ building: category }, buildable.instances.length)
       }
     }

--- a/src/metricGroups/pipes.ts
+++ b/src/metricGroups/pipes.ts
@@ -1,13 +1,15 @@
 import { MetricGroup } from './_MetricGroup'
 import { type Lookups } from '../types/lookups.type'
 import {
-  type ArrayProperty,
-  type StructProperty,
   type SaveComponent,
   type SaveEntity,
 } from '@etothepii/satisfactory-file-parser'
 import { getDistance } from '../utils/spatialMath'
 import { pathToBuilding } from '../staticData/staticData'
+import {
+  type SplineArrayProperty,
+  type SplinePointProperty,
+} from '../types/splineArrayProperty.type'
 
 const metrics = new MetricGroup('satisfactory_savegame_pipes')
   .addGauge(
@@ -37,8 +39,8 @@ export const parser = (object: SaveComponent | SaveEntity, lookups: Lookups): vo
 
     const mk = building.className.match(/mk(\d)/i)?.at(1) ?? '1'
 
-    const { totalLength: pipeLength } = (object.properties?.mSplineData as ArrayProperty<StructProperty>)?.values
-      ?.reduce<{ totalLength: number, previousPoint: StructProperty | null }>(({ totalLength, previousPoint }, splinePoint) => {
+    const { totalLength: pipeLength } = (object.properties?.mSplineData as SplineArrayProperty)?.values
+      ?.reduce<{ totalLength: number, previousPoint: SplinePointProperty | null }>(({ totalLength, previousPoint }, splinePoint) => {
       return {
         totalLength: totalLength + (
           previousPoint

--- a/src/metricGroups/trains.ts
+++ b/src/metricGroups/trains.ts
@@ -1,12 +1,14 @@
 import { MetricGroup } from './_MetricGroup'
 import { type Lookups } from '../types/lookups.type'
 import {
-  type ArrayProperty,
-  type StructProperty,
   type SaveComponent,
   type SaveEntity,
 } from '@etothepii/satisfactory-file-parser'
 import { getDistance } from '../utils/spatialMath'
+import {
+  type SplineArrayProperty,
+  type SplinePointProperty,
+} from '../types/splineArrayProperty.type'
 
 const metrics = new MetricGroup('satisfactory_savegame_trains')
   .addGauge(
@@ -37,8 +39,8 @@ export const parser = (object: SaveComponent | SaveEntity, lookups: Lookups): vo
   }
 
   if (object.typePath.startsWith('/Game/FactoryGame/Buildable/Factory/Train/Track')) {
-    const { totalLength } = (object.properties?.mSplineData as ArrayProperty<StructProperty>)?.values
-      ?.reduce<{ totalLength: number, previousPoint: StructProperty | null }>(({ totalLength, previousPoint }, splinePoint) => {
+    const { totalLength } = (object.properties?.mSplineData as SplineArrayProperty)?.values
+      ?.reduce<{ totalLength: number, previousPoint: SplinePointProperty | null }>(({ totalLength, previousPoint }, splinePoint) => {
       return {
         totalLength: totalLength + (
           previousPoint

--- a/src/types/splineArrayProperty.type.ts
+++ b/src/types/splineArrayProperty.type.ts
@@ -1,0 +1,23 @@
+import {
+  type StructArrayProperty,
+  type StructProperty,
+  type vec3,
+} from '@etothepii/satisfactory-file-parser'
+
+interface Vec3StructProperty extends StructProperty {
+  value: vec3
+}
+interface SplinePointData {
+  type: 'SplinePointData'
+  properties: {
+    Location: Vec3StructProperty
+    ArriveTangent: Vec3StructProperty
+    LeaveTangent: Vec3StructProperty
+  }
+}
+export interface SplinePointProperty extends StructProperty {
+  value: SplinePointData
+}
+export interface SplineArrayProperty extends StructArrayProperty {
+  values: SplinePointProperty[]
+}

--- a/src/utils/loadLocation.ts
+++ b/src/utils/loadLocation.ts
@@ -36,5 +36,7 @@ export const loadLocation = async (location: string): Promise<ArrayBuffer> => {
     if (LOG_LEVEL === 'debug') console.log(`Reading savefile from ${localPath}`)
   }
 
-  return (await readFile(resolve(localPath))).buffer
+  const buffer = await readFile(resolve(localPath))
+  // Convert Buffer to proper ArrayBuffer (Buffer.buffer can have offset issues)
+  return new Uint8Array(buffer).buffer
 }

--- a/src/utils/spatialMath.ts
+++ b/src/utils/spatialMath.ts
@@ -1,10 +1,7 @@
-interface CoordinateObject {
-  x: number
-  y: number
-  z: number
-}
+import { type vec3 } from '@etothepii/satisfactory-file-parser'
+
 type CoordinateArray = [number, number, number]
-type AnyCoordinate = CoordinateObject | CoordinateArray
+type AnyCoordinate = vec3 | CoordinateArray
 
 /**
  * Calculates the straight distance between two points in 3D space. Does not account for curvature.


### PR DESCRIPTION
## Summary

Updates the project to use `@etothepii/satisfactory-file-parser` v3.3.0 which has breaking API changes.

### Changes Made

1. **package.json**: Updated parser dependency from `^1.1.1` to `^3.3.0`

2. **src/extractMetrics.ts**: 
   - `Parser.ParseSave` now accepts `ArrayBuffer` directly (removed `Uint8Array` wrapper)
   - `save.levels` is now an object instead of an array, updated to use `Object.values()`

3. **src/metricGroups/buildings.ts**:
   - Lightweight buildables now use `typeReference.pathName` instead of `typePath` directly
   - Added null check to skip buildables without valid typeReference

4. **src/utils/loadLocation.ts**:
   - Fixed Buffer to ArrayBuffer conversion to avoid offset issues with `Buffer.buffer`

### Issue Fixed

TypeError when parsing lightweight buildables (walls, foundations):
```
TypeError: Cannot read properties of undefined (reading 'split')
    at parser5 (/app/dist/express.js:51429:45)
    at extractMetrics (/app/dist/express.js:51567:7)
```

### Testing

Tested against Satisfactory 1.0 save files with lightweight buildables (walls, foundations, etc.).