### PR TITLE
Fixing issue with missing resource type

### DIFF
--- a/src/metricGroups/resources.ts
+++ b/src/metricGroups/resources.ts
@@ -89,6 +89,8 @@ export const parser = (object: SaveComponent | SaveEntity, lookups: Lookups): vo
       return
     }
 
+    if (!object.properties?.mStorageInventory?.value?.pathName) return
+
     const items = iterateInventory(object, lookups)
     for (const [itemName, quantity] of items) {
       metrics.getGauge('storage_containers_total').inc({ item: itemName }, quantity)
@@ -189,7 +191,10 @@ export const parser = (object: SaveComponent | SaveEntity, lookups: Lookups): vo
     // and its not readily available in the parsed entity, so we cant account for overclocking of the parent smasher
 
     const resource = pathToResourceNode((object.properties.mExtractableResource as ObjectProperty).value.pathName)
-    if (!resource) throw new Error('Resource not found: ' + (object.properties.mExtractableResource as ObjectProperty).value.pathName)
+    if (!resource) {
+      process.stderr.write(`Resource node not found in static data: ${(object.properties.mExtractableResource as ObjectProperty).value.pathName}\n`)
+      return
+    }
 
     // Oil frackers claim to extract "Desc_LiquidOilWell_C" but the actual resource is "Desc_LiquidOil_C" (Crude Oil)
     const item = staticData.items[resource.item.replace('Well_C', '_C')]


### PR DESCRIPTION
First up, thank you for your work! Very fun project!

The resourceNodes.ts static data is a hardcoded mapping of resource node instance names to their resource types. These instance names include UUIDs that are generated per-map/per-save.

My file had a resource node (BP_ResourceNode20_UAID_04D9F5D42711A7C902_1245462149) that doesn't exist in that mapping.

Error was:
```
Error: Inventory not found: undefined
    at iterateInventory (/app/src/metricGroups/resources.ts:47:25)
    at parser (/app/src/metricGroups/resources.ts:92:19)
    at extractMetrics (/app/src/extractMetrics.ts:50:7)
```

This makes that optional. Metrics loaded perfectly after handling the error
